### PR TITLE
fix(chore): add script to main layout to preserve css

### DIFF
--- a/packages/astro-camomilla-integration/src/layouts/MainLayout.astro
+++ b/packages/astro-camomilla-integration/src/layouts/MainLayout.astro
@@ -1,8 +1,7 @@
 ---
 import SeoHead from "../components/SeoHead.astro";
 const seo = Astro.locals.camomilla.page;
-import { ClientRouter } from 'astro:transitions';
-
+import { ClientRouter } from "astro:transitions";
 ---
 
 <!doctype html>
@@ -17,6 +16,27 @@ import { ClientRouter } from 'astro:transitions';
       <SeoHead seo={seo} />
     </slot>
     <slot name="seo-head-after" />
+    <script is:inline>
+      document.addEventListener("astro:before-swap", (event) => {
+        const DATA_ANCHOR = 'style[type="text/css"]';
+        const DATA_ASTRO_ANCHOR = "data-vite-dev-id";
+
+        const newDocument = event.newDocument;
+        const newHead = newDocument.head;
+
+        document.head.querySelectorAll(DATA_ANCHOR).forEach((oldStyle) => {
+          if (
+            ![...newHead.querySelectorAll(DATA_ANCHOR)].some(
+              (el) => el[DATA_ASTRO_ANCHOR] === oldStyle[DATA_ASTRO_ANCHOR]
+            )
+          ) {
+            const newStyle = oldStyle.cloneNode();
+            newStyle.textContent = oldStyle.textContent;
+            newHead?.appendChild(newStyle);
+          }
+        });
+      });
+    </script>
   </head>
   <body>
     <slot name="header" />


### PR DESCRIPTION
## 🛠️ New script to preserve `<style>` tags on route changes

I’ve added a script that addresses the issue of losing styles when the `clientRouter` swaps out the `<head>` and removes existing `<style>` tags. In a nutshell:

- **What it does**  
  1. Before the route change, it collects all `<style>` tags in the `<head>`.  
  2. After the swap, it immediately reinjects them, preserving previously loaded CSS.

- **Current limitations**  
  - Right now, the script only includes `<style>` tags with `type="text/css"`.  
  - We need to verify in production whether the `data-vite-dev-id` attribute is preserved (currently not handled).