### PR TITLE
chore: update vite build code-splitting

### DIFF
--- a/packages/astro-camomilla-integration/src/integration.ts
+++ b/packages/astro-camomilla-integration/src/integration.ts
@@ -22,9 +22,10 @@ export const integration = defineIntegration({
                   ...defaultOptions,
                 },
               },
-              plugins: [
-                vitePluginTemplateMapper(options.templatesIndex),
-              ],
+              plugins: [vitePluginTemplateMapper(options.templatesIndex)],
+              build: {
+                cssCodeSplit: false,
+              },
             },
           });
           addMiddleware({


### PR DESCRIPTION
### Overview
This PR fixes the CSS loading problem for the server-side templates by disabling Vite’s code-splitting.

---

**⚠️ Note:**  
The root issue still persists because those templates aren’t currently used in the project. During the Astro build process, they’re skipped and not injected into the page. We’ll need to revisit this later to ensure these templates are properly built and included.
