### PR TITLE
SeoHead: keywords field management

### DIFF
--- a/packages/astro-camomilla-integration/src/components/SeoHead.astro
+++ b/packages/astro-camomilla-integration/src/components/SeoHead.astro
@@ -4,7 +4,7 @@ const { seo = {} } = Astro.props
 const computedSeo = {
   title: seo?.title,
   description: seo?.description || seo?.og_description,
-  keywords: seo?.keywords || [],
+  keywords: seo?.keywords,
   ogType: seo?.og_type || 'website',
   ogTitle: seo?.og_title || seo?.title,
   ogDescription: seo?.og_description || seo?.description,
@@ -29,7 +29,7 @@ const computedSeo = {
 <title>{computedSeo.title}</title>
 <link rel="canonical" href={computedSeo.canonicalUrl} />
 <meta name="description" content={computedSeo.description} />
-<meta name="keywords" content={computedSeo.keywords?.join(', ')} />
+{computedSeo.keywords && (<meta name="keywords" content={computedSeo.keywords} />) }
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content={computedSeo.ogType} />

--- a/tests/e2e/mocks/handlers.ts
+++ b/tests/e2e/mocks/handlers.ts
@@ -8,7 +8,7 @@ export const handlers = [
       is_public: true,
       title: 'Seo Mocked Title',
       description: 'Seo mocked description',
-      keywords: ['MockedKey', 'MockedKey2'],
+      keywords: 'MockedKey, MockedKey2',
       og_description: 'Seo mocked og_description',
       og_title: 'Seo mocked og_title',
       og_type: 'Seo mocked og_type',


### PR DESCRIPTION
Seo Head expect char field prop for keyword field;
check if there is content, otherwise avoid render tag.
Updated mocked data for test