### PR TITLE
feat: camomilla 6.5 page lifecycle, preview router, and menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,28 @@ export default templates;
 > [!NOTE]  
 > Even if this approach is more fine-grained, it is recommended to always declare a generic `error` template to handle unexpected errors.
 
-## Draft Pages
+## Draft Pages and Previews
 
-This integration will check for the `is_public` field in the Camomilla CMS response to determine if a page is a draft or not.
-If the `is_public` field is set to `false`, the integration will return a `404` status code. If you need to access draft pages, you can add `?preview=true` to the URL.
+Camomilla 6.4+ enforces page visibility **server-side**: the public `pages-router` 404s every trashed, draft, or scheduled-first-publish row before they ever reach the integration. The middleware no longer client-side-checks `is_public` — that gate moved into the CMS.
+
+To preview, authenticated users append `?preview=true` to the URL. The integration then makes a single authenticated request to the camomilla preview router:
+
+```
+GET /api/camomilla/pages-router-preview/<permalink>
+```
+
+This endpoint covers **both** preview cases uniformly:
+
+- **Public page with a pending draft** — the live row is the base and the draft fields are layered on top. This is the most common preview flow (editor checking how their pending edits will look on an already-live page).
+- **Non-public page** (trashed, draft, scheduled-first-publish) — the `is_public` gate is bypassed so the editor can preview content that the public router would 404.
+
+The response carries `has_draft: true` whenever an overlay was applied. The endpoint does **not** trigger `publish_if_due()` — a preview shows the *current* draft state, not the post-materialised one. The visitor's `sessionid` and `csrftoken` cookies are forwarded. If the cookies are absent, the user lacks permission, or the permalink doesn't resolve, the integration falls through to the public router (which serves the live page for an already-public row, or 404s otherwise). Any response on a `?preview=true` URL is marked `NEVER_CACHE` so an editor's view never poisons the shared cache with a different user's state.
+
+The page payload exposed in `Astro.locals.camomilla.page` carries:
+
+- `status: 'PUB' | 'DRF' | 'PLA' | 'TRS'` — the lifecycle label (derived server-side from `published_at` + `deleted_at` + the Draft table; not a column).
+- `published_at: string | null` — replaces the legacy `publication_date`. Per-language: each language has its own `published_at_<lang>` column on the page row.
+- `has_draft?: boolean` / `has_scheduled_draft?: boolean` — present only on the authenticated preview response, never on the public router output.
 
 ## Forwarded Headers
 

--- a/example/src/components/LangSwitch.astro
+++ b/example/src/components/LangSwitch.astro
@@ -1,0 +1,58 @@
+---
+/**
+ * Inline language switch. Reads ``page.alternates`` (the dict returned by
+ * camomilla's ``AbstractPage.alternate_urls()`` → keyed by lang code,
+ * value is the resolved URL in that language or ``null`` when that
+ * language isn't public).
+ *
+ * The currently active language is whichever URL prefix Astro served the
+ * request from — we read it from the camomilla page's ``permalink`` plus
+ * the path prefix. The page already carries the per-language permalinks
+ * in ``alternates`` for the OTHER languages, so the active one is
+ * "everything not in alternates".
+ */
+const page = Astro.locals.camomilla?.page as any
+const alternates: Record<string, string | null> = page?.alternates ?? {}
+
+// Active language: the locale prefix of the current URL, or the
+// configured default. Camomilla strips the active language from
+// ``alternates``, so we know the current language is whatever isn't
+// listed there.
+const pathname = Astro.url.pathname
+const prefixMatch = pathname.match(/^\/([a-z]{2})(\/|$)/)
+const activeLang = prefixMatch ? prefixMatch[1] : 'en'
+
+// Languages the application knows about. Mirrors LANGUAGES in
+// example/camomilla_example/settings.py — keep both lists in sync.
+const KNOWN_LANGUAGES = ['en', 'it']
+---
+
+<div class="lang-switch" aria-label="language">
+  {
+    KNOWN_LANGUAGES.map((code) => {
+      if (code === activeLang) {
+        return (
+          <span class="lang-switch__chip lang-switch__chip--active" title={code}>
+            {code.toUpperCase()}
+          </span>
+        )
+      }
+      const url = alternates[code]
+      if (url) {
+        return (
+          <a class="lang-switch__chip" href={url} title={code}>
+            {code.toUpperCase()}
+          </a>
+        )
+      }
+      return (
+        <span
+          class="lang-switch__chip lang-switch__chip--disabled"
+          title={`${code}: not available`}
+        >
+          {code.toUpperCase()}
+        </span>
+      )
+    })
+  }
+</div>

--- a/example/src/components/MenuRenderer.astro
+++ b/example/src/components/MenuRenderer.astro
@@ -1,0 +1,25 @@
+---
+import type { CamomillaMenuNode } from '@camomillacms/astro-integration/types/camomillaMenu'
+// Self-import: Astro doesn't have an ``Astro.self`` builtin, so the
+// canonical recursive-render pattern is to import the component from
+// its own file and use it for child nodes.
+import Self from './MenuRenderer.astro'
+
+interface Props {
+  nodes: CamomillaMenuNode[]
+}
+const { nodes } = Astro.props
+---
+
+{
+  nodes.length > 0 && (
+    <ul>
+      {nodes.map((node) => (
+        <li>
+          {node.link?.url ? <a href={node.link.url}>{node.title}</a> : <span>{node.title}</span>}
+          {node.nodes && node.nodes.length > 0 && <Self nodes={node.nodes} />}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/example/src/components/PreviewBanner.astro
+++ b/example/src/components/PreviewBanner.astro
@@ -1,0 +1,24 @@
+---
+/**
+ * Shows a "Preview mode" banner whenever the page was resolved through the
+ * authenticated ``pages-router-preview`` endpoint. ``is_preview`` is set by
+ * the integration for every previewed state — including a non-public page
+ * with no pending Draft, where ``has_draft`` is false. Keying off
+ * ``has_draft`` alone would silently render such pages with no indication
+ * that you're looking at non-public content. When a draft overlay *was*
+ * applied we say so.
+ */
+const page = Astro.locals.camomilla?.page as any
+const isPreview = Boolean(page?.is_preview)
+const hasDraft = Boolean(page?.has_draft)
+---
+
+{
+  isPreview && (
+    <div class="preview-banner">
+      {hasDraft
+        ? '📝 Preview mode — draft fields overlaid on the live page'
+        : '📝 Preview mode — non-public page'}
+    </div>
+  )
+}

--- a/example/src/components/SiteFooter.astro
+++ b/example/src/components/SiteFooter.astro
@@ -1,0 +1,30 @@
+---
+import MenuRenderer from './MenuRenderer.astro'
+import { fetchMenu } from '@camomillacms/astro-integration/menus'
+
+/**
+ * Footer for the demo site. Mirrors SiteHeader: the nav comes from the
+ * ``footer`` menu in the camomilla admin. The ``footer`` menu is seeded
+ * by ``seed_demo``.
+ */
+const menu = await fetchMenu('footer', Astro)
+
+const page = Astro.locals.camomilla?.page as any
+const templateFile = page?.template_file ?? ''
+---
+
+<footer class="site">
+  <div class="container">
+    <span>
+      © Camomilla demo · rendered by astro from
+      {templateFile ? <code>{templateFile}</code> : <code>fallback</code>}
+    </span>
+    {
+      menu && (
+        <nav>
+          <MenuRenderer nodes={menu.nodes} />
+        </nav>
+      )
+    }
+  </div>
+</footer>

--- a/example/src/components/SiteHeader.astro
+++ b/example/src/components/SiteHeader.astro
@@ -1,0 +1,41 @@
+---
+import LangSwitch from './LangSwitch.astro'
+import MenuRenderer from './MenuRenderer.astro'
+import { fetchMenu } from '@camomillacms/astro-integration/menus'
+
+/**
+ * Header for the demo site. The main nav comes from the ``main`` menu
+ * managed in the camomilla admin and seeded by ``seed_demo``. The
+ * ``fetchMenu`` helper forwards the visitor's session cookies, so
+ * logged-in staff see menus immediately. Anonymous visitors fall through
+ * to a null menu and the nav is omitted (camomilla's ``MenuViewSet``
+ * requires auth by default — override its ``permission_classes`` if you
+ * want anon access).
+ *
+ * Lang switch lives on the right and is always rendered (it reads from
+ * the page's ``alternates`` and works for anyone).
+ */
+const menu = await fetchMenu('main', Astro)
+
+const pathname = Astro.url.pathname
+const prefixMatch = pathname.match(/^\/([a-z]{2})(\/|$)/)
+const langPrefix = prefixMatch ? `/${prefixMatch[1]}` : ''
+---
+
+<header class="site">
+  <div class="container">
+    <div class="brand">
+      <a href={langPrefix || '/'}>Camomilla Demo</a>
+    </div>
+    <div class="header-right">
+      {
+        menu && (
+          <nav>
+            <MenuRenderer nodes={menu.nodes} />
+          </nav>
+        )
+      }
+      <LangSwitch />
+    </div>
+  </div>
+</header>

--- a/example/src/components/SiteLayout.astro
+++ b/example/src/components/SiteLayout.astro
@@ -1,0 +1,31 @@
+---
+import MainLayout from '@camomillacms/astro-integration/layouts/MainLayout.astro'
+import SiteHeader from './SiteHeader.astro'
+import SiteFooter from './SiteFooter.astro'
+import PreviewBanner from './PreviewBanner.astro'
+
+/**
+ * Demo-site layout. Wraps the integration's MainLayout (which handles
+ * the ``<head>`` + SEO tags) and slots in the shared header, footer,
+ * and preview banner. Page templates only need to fill the default
+ * slot with their content.
+ */
+const pathname = Astro.url.pathname
+const prefixMatch = pathname.match(/^\/([a-z]{2})(\/|$)/)
+const lang = prefixMatch ? prefixMatch[1] : 'en'
+---
+
+<MainLayout lang={lang}>
+  <slot name="seo-head-before" slot="seo-head-before" />
+  <slot name="seo-head" slot="seo-head" />
+  <slot name="seo-head-after" slot="seo-head-after" />
+
+  <PreviewBanner />
+  <SiteHeader />
+  <main>
+    <div class="container">
+      <slot />
+    </div>
+  </main>
+  <SiteFooter />
+</MainLayout>

--- a/example/src/styles/main.scss
+++ b/example/src/styles/main.scss
@@ -1,22 +1,240 @@
+// Demo site styles — visual parity with example/website/templates/website/base.html
+// on the camomilla side, so the same camomilla page rendered through django vs astro
+// looks essentially identical.
+
+:root {
+  --fg: #0d1117;
+  --fg-soft: #475569;
+  --bg: #f7fafc;
+  --bg-card: #ffffff;
+  --border: #e2e8f0;
+  --accent: #2563eb;
+  --accent-fg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --fg: #f1f5f9;
+    --fg-soft: #94a3b8;
+    --bg: #0d1117;
+    --bg-card: #161b22;
+    --border: #30363d;
+    --accent: #60a5fa;
+    --accent-fg: #0d1117;
+  }
+}
+
+* { box-sizing: border-box; }
+html, body { height: 100%; }
 body {
-    font-family: Arial, sans-serif;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  color: var(--fg);
+  background: var(--bg);
+  line-height: 1.5;
+  // Sticky footer: column flex so <main> stretches and pushes the footer down.
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+a { color: var(--accent); text-decoration: none; &:hover { text-decoration: underline; } }
+
+.container { max-width: 980px; margin: 0 auto; padding: 0 1.5rem; }
+
+header.site {
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-card);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+
+  .container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  .brand { font-weight: 700; font-size: 1.125rem; }
+
+  nav ul {
+    list-style: none;
     margin: 0;
     padding: 0;
-    background-color: #19181b;
-    font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
-      "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
-      "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
-
+    display: flex;
+    gap: 1.5rem;
+    align-items: center;
   }
-
-  h1, h2 {
-    color: #f0f0f0;
-    text-align: center;
-    margin-top: 50px;
+  nav li { position: relative; }
+  nav a { color: var(--fg); }
+  nav ul ul {
+    position: absolute;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    padding: 0.5rem 0;
+    margin-top: 0.5rem;
+    min-width: 12rem;
+    display: none;
   }
+  nav li:hover > ul { display: block; }
+  nav ul ul li a { display: block; padding: 0.5rem 1rem; }
+}
 
-  p {
-    color: #f0f0f0;
-    text-align: center;
-    margin-top: 20px;
+main {
+  padding: 2.5rem 0 4rem;
+  flex: 1 0 auto;
+}
+
+.breadcrumbs {
+  font-size: 0.875rem;
+  color: var(--fg-soft);
+  margin-bottom: 1.5rem;
+  a { color: var(--fg-soft); }
+  span:not(:last-child)::after { content: " / "; padding: 0 0.25rem; }
+}
+
+footer.site {
+  flex: 0 0 auto;
+  border-top: 1px solid var(--border);
+  padding: 2rem 0;
+  color: var(--fg-soft);
+  font-size: 0.875rem;
+  background: var(--bg-card);
+
+  .container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
   }
+  nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 1.25rem;
+  }
+}
+
+.header-right { display: flex; align-items: center; gap: 1rem; }
+
+.lang-switch {
+  display: inline-flex;
+  gap: 0.25rem;
+
+  &__chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2rem;
+    padding: 0.2rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--bg-card);
+    color: var(--fg-soft);
+    text-decoration: none;
+
+    &:hover { background: var(--border); text-decoration: none; }
+    &--active {
+      background: var(--accent);
+      color: var(--accent-fg);
+      border-color: var(--accent);
+    }
+    &--disabled { opacity: 0.4; cursor: not-allowed; }
+  }
+}
+
+.preview-banner {
+  background: var(--accent);
+  color: var(--accent-fg);
+  text-align: center;
+  padding: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+}
+
+.grid { display: grid; gap: 1.25rem; }
+.grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+@media (max-width: 720px) {
+  .grid-3, .grid-2 { grid-template-columns: 1fr; }
+  header.site nav ul { gap: 1rem; }
+}
+
+.tag {
+  display: inline-block;
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  background: var(--border);
+  border-radius: 999px;
+  color: var(--fg-soft);
+}
+
+.feature-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  .feature-icon { font-size: 1.75rem; }
+  h3 { margin: 0; font-size: 1rem; }
+  p { margin: 0; color: var(--fg-soft); font-size: 0.95rem; }
+}
+
+blockquote.testimonial {
+  margin: 2rem 0;
+  padding: 1.5rem 2rem;
+  background: var(--bg-card);
+  border-left: 4px solid var(--accent);
+  font-size: 1.125rem;
+  font-style: italic;
+  color: var(--fg);
+
+  cite {
+    display: block;
+    margin-top: 0.75rem;
+    font-style: normal;
+    font-size: 0.875rem;
+    color: var(--fg-soft);
+  }
+}
+
+.methods {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+
+  li {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .method-label { color: var(--fg-soft); }
+}
+
+.cta-button {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-radius: 6px;
+  font-weight: 500;
+  &:hover { text-decoration: none; opacity: 0.92; }
+}
+
+h1 { margin: 0 0 0.5rem; font-size: 2rem; }
+h2 { margin: 2rem 0 0.75rem; font-size: 1.5rem; }
+.lead { font-size: 1.125rem; color: var(--fg-soft); margin: 0 0 1.5rem; }

--- a/example/src/templates/index.js
+++ b/example/src/templates/index.js
@@ -1,7 +1,29 @@
 import ChangeList from './admin/change_list.astro'
 import DefaultTemplate from './default.astro'
 
+import SiteHome from './site/home.astro'
+import SiteDefault from './site/default.astro'
+import SiteServices from './site/services.astro'
+import SiteBlogList from './site/blog_list.astro'
+import SiteArticleDetail from './site/article_detail.astro'
+
+/**
+ * Maps the ``template_file`` value returned by the camomilla
+ * ``pages-router`` (or ``pages-router-preview``) response to an Astro
+ * component. The lookup is exact, so the keys must match the full path
+ * including the ``.html`` extension exactly as set on ``Page.template``
+ * in the camomilla seed.
+ */
 const templates = {
+  // Demo site templates — matched 1:1 to example/website/templates/website/*
+  // on the camomilla side. Same content, same shape, rendered through astro.
+  'website/pages/home.html': SiteHome,
+  'website/pages/default.html': SiteDefault,
+  'website/pages/services.html': SiteServices,
+  'website/pages/blog_list.html': SiteBlogList,
+  'website/articles/detail.html': SiteArticleDetail,
+
+  // Legacy / debug
   'defaults/pages/default': DefaultTemplate,
   'admin/change_list': ChangeList
 }

--- a/example/src/templates/site/article_detail.astro
+++ b/example/src/templates/site/article_detail.astro
@@ -1,0 +1,42 @@
+---
+import SiteLayout from '../../components/SiteLayout.astro'
+
+/**
+ * Article detail — maps to camomilla's ``website/articles/detail.html``.
+ * The ``Article`` model on the camomilla side ships ``content`` and
+ * ``tags`` in the serialized response (in addition to standard
+ * AbstractPage fields).
+ */
+const page = Astro.locals.camomilla?.page as any
+const breadcrumbs: Array<{ permalink: string; title: string }> = page?.breadcrumbs ?? []
+const tags: Array<{ name: string }> = page?.tags ?? []
+const author = page?.author
+---
+
+<SiteLayout>
+  {
+    breadcrumbs.length > 1 && (
+      <nav class="breadcrumbs" aria-label="breadcrumb">
+        {breadcrumbs.map((crumb, i) => (
+          <span>
+            {i < breadcrumbs.length - 1 ? (
+              <a href={crumb.permalink}>{crumb.title}</a>
+            ) : (
+              <>{crumb.title}</>
+            )}
+          </span>
+        ))}
+      </nav>
+    )
+  }
+
+  <article>
+    <h1>{page?.title}</h1>
+    {page?.description && <p class="lead">{page.description}</p>}
+    <p style="color:var(--fg-soft);font-size:.875rem;">
+      {tags.map((tag) => <span class="tag">{tag.name}</span>)}
+      {author?.username && <> · by {author.username}</>}
+    </p>
+    {page?.content && <div class="article-content" set:html={page.content} />}
+  </article>
+</SiteLayout>

--- a/example/src/templates/site/blog_list.astro
+++ b/example/src/templates/site/blog_list.astro
@@ -1,0 +1,64 @@
+---
+import SiteLayout from '../../components/SiteLayout.astro'
+
+/**
+ * Blog listing — maps to camomilla's ``website/pages/blog_list.html``.
+ * Articles are hardcoded for the demo (the camomilla articles API
+ * requires authentication for anonymous reads in the default settings).
+ * In a real integration you would either expose the endpoint publicly
+ * or fetch with a service token.
+ */
+const page = Astro.locals.camomilla?.page as any
+const data = page?.template_data ?? {}
+
+const pathname = Astro.url.pathname
+const prefixMatch = pathname.match(/^\/([a-z]{2})(\/|$)/)
+const langPrefix = prefixMatch ? `/${prefixMatch[1]}` : ''
+const isIt = prefixMatch && prefixMatch[1] === 'it'
+const t = (en: string, it: string) => (isIt ? it : en)
+
+const articles = [
+  {
+    href: `${langPrefix}/blog/hello-world`,
+    title: t('Hello, world', 'Ciao, mondo'),
+    description: t(
+      'Our first post. Camomilla is up and running.',
+      'Il nostro primo post. Camomilla è online.'
+    ),
+    tags: [t('Technology', 'Tecnologia')]
+  },
+  {
+    href: `${langPrefix}/blog/on-design`,
+    title: t('On Design', 'Sul design'),
+    description: t(
+      'A few thoughts about content modeling.',
+      'Qualche riflessione sul modeling dei contenuti.'
+    ),
+    tags: [t('Design', 'Design'), t('Business', 'Business')]
+  }
+]
+---
+
+<SiteLayout>
+  <h1>{page?.title}</h1>
+  {page?.description && <p class="lead">{page.description}</p>}
+  {data.intro && <p>{data.intro}</p>}
+
+  <div class="grid grid-2">
+    {
+      articles.map((article) => (
+        <article class="card">
+          <h2 style="margin-top:0;">
+            <a href={article.href}>{article.title}</a>
+          </h2>
+          <p>{article.description}</p>
+          <p style="font-size:.875rem;color:var(--fg-soft);">
+            {article.tags.map((tag) => (
+              <span class="tag">{tag}</span>
+            ))}
+          </p>
+        </article>
+      ))
+    }
+  </div>
+</SiteLayout>

--- a/example/src/templates/site/default.astro
+++ b/example/src/templates/site/default.astro
@@ -1,0 +1,112 @@
+---
+import SiteLayout from '../../components/SiteLayout.astro'
+
+/**
+ * Default page template — maps to camomilla's ``website/pages/default.html``.
+ * Reads optional blocks out of ``page.template_data``: ``body`` (HTML
+ * string), ``values``, ``team``, ``features``, ``methods``. Mirrors the
+ * django template so the same content renders identically.
+ */
+const page = Astro.locals.camomilla?.page as any
+const data = page?.template_data ?? {}
+const breadcrumbs: Array<{ permalink: string; title: string }> = page?.breadcrumbs ?? []
+---
+
+<SiteLayout>
+  {
+    breadcrumbs.length > 1 && (
+      <nav class="breadcrumbs" aria-label="breadcrumb">
+        {breadcrumbs.map((crumb, i) => (
+          <span>
+            {i < breadcrumbs.length - 1 ? (
+              <a href={crumb.permalink}>{crumb.title}</a>
+            ) : (
+              <>{crumb.title}</>
+            )}
+          </span>
+        ))}
+      </nav>
+    )
+  }
+
+  <article>
+    <h1>{page?.title}</h1>
+    {page?.description && <p class="lead">{page.description}</p>}
+
+    {data.body && <Fragment set:html={data.body} />}
+
+    {
+      data.values && data.values.length > 0 && (
+        <>
+          <h2>What we care about</h2>
+          <div class="grid grid-3">
+            {data.values.map((value: { title: string; description: string }) => (
+              <div class="card feature-card">
+                <h3>{value.title}</h3>
+                <p>{value.description}</p>
+              </div>
+            ))}
+          </div>
+        </>
+      )
+    }
+
+    {
+      data.team && data.team.length > 0 && (
+        <>
+          <h2>Team</h2>
+          <div class="grid grid-3">
+            {data.team.map((member: { name: string; role: string; bio?: string }) => (
+              <div class="card feature-card">
+                <h3>{member.name}</h3>
+                <p style="color:var(--fg-soft);font-size:.875rem;margin:0;">{member.role}</p>
+                {member.bio && <p>{member.bio}</p>}
+              </div>
+            ))}
+          </div>
+        </>
+      )
+    }
+
+    {
+      data.features && data.features.length > 0 && (
+        <>
+          <h2>What you get</h2>
+          <div class="grid grid-3">
+            {data.features.map((feature: { icon?: string; title: string; description: string }) => (
+              <div class="card feature-card">
+                {feature.icon && (
+                  <span class="feature-icon" aria-hidden="true">
+                    {feature.icon}
+                  </span>
+                )}
+                <h3>{feature.title}</h3>
+                <p>{feature.description}</p>
+              </div>
+            ))}
+          </div>
+        </>
+      )
+    }
+
+    {
+      data.methods && data.methods.length > 0 && (
+        <>
+          <h2>How to reach us</h2>
+          <ul class="methods">
+            {data.methods.map((method: { label: string; value: string; href?: string }) => (
+              <li>
+                <span class="method-label">{method.label}</span>
+                {method.href ? (
+                  <a href={method.href}>{method.value}</a>
+                ) : (
+                  <span>{method.value}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </>
+      )
+    }
+  </article>
+</SiteLayout>

--- a/example/src/templates/site/home.astro
+++ b/example/src/templates/site/home.astro
@@ -1,0 +1,72 @@
+---
+import SiteLayout from '../../components/SiteLayout.astro'
+
+/**
+ * Renders the camomilla homepage with hero / features / testimonial.
+ * Maps to camomilla's ``website/pages/home.html`` via templates/index.js.
+ *
+ * The shape of ``page.template_data`` is exactly what the camomilla seed
+ * embeds (see ``seed_demo.py`` PAGE_FIXTURES[/]). ``page`` is the
+ * deserialized ``pages-router`` response — translations have already been
+ * collapsed to the active language by the time we get it here, and any
+ * camomilla permalinks in ``template_data`` come back pre-resolved to
+ * the active-language URL (see ``AbstractPageMixin.to_representation``).
+ * That means ``hero.cta_url`` is already ``"/it/about/"`` on /it/ and
+ * ``"/about/"`` on the default route — astro doesn't have to know how
+ * Django's ``i18n_patterns`` builds URLs.
+ */
+const page = Astro.locals.camomilla?.page as any
+const data = page?.template_data ?? {}
+const hero = data.hero ?? {}
+const features: Array<{ icon?: string; title: string; description: string }> = data.features ?? []
+const testimonial = data.testimonial ?? null
+---
+
+<SiteLayout>
+  <section class="hero">
+    <h1>{hero.headline ?? page?.title}</h1>
+    {hero.subheadline && <p class="lead">{hero.subheadline}</p>}
+    {
+      hero.cta_url && (
+        <p>
+          <a href={hero.cta_url} class="cta-button">
+            {hero.cta_label ?? 'Learn more'}
+          </a>
+        </p>
+      )
+    }
+  </section>
+
+  {
+    features.length > 0 && (
+      <>
+        <h2>Highlights</h2>
+        <div class="grid grid-3">
+          {features.map((feature) => (
+            <div class="card feature-card">
+              {feature.icon && (
+                <span class="feature-icon" aria-hidden="true">
+                  {feature.icon}
+                </span>
+              )}
+              <h3>{feature.title}</h3>
+              <p>{feature.description}</p>
+            </div>
+          ))}
+        </div>
+      </>
+    )
+  }
+
+  {
+    testimonial && (
+      <blockquote class="testimonial">
+        “{testimonial.quote}”
+        <cite>
+          — {testimonial.author}
+          {testimonial.role && <>, {testimonial.role}</>}
+        </cite>
+      </blockquote>
+    )
+  }
+</SiteLayout>

--- a/example/src/templates/site/services.astro
+++ b/example/src/templates/site/services.astro
@@ -1,0 +1,71 @@
+---
+import SiteLayout from '../../components/SiteLayout.astro'
+
+/**
+ * Services landing — maps to camomilla's ``website/pages/services.html``.
+ * Child service pages are hardcoded for the demo (anonymous fetch
+ * against /api/camomilla/pages/ requires auth). The links match what
+ * ``seed_demo`` creates.
+ */
+const page = Astro.locals.camomilla?.page as any
+const data = page?.template_data ?? {}
+const breadcrumbs: Array<{ permalink: string; title: string }> = page?.breadcrumbs ?? []
+
+const pathname = Astro.url.pathname
+const prefixMatch = pathname.match(/^\/([a-z]{2})(\/|$)/)
+const langPrefix = prefixMatch ? `/${prefixMatch[1]}` : ''
+const isIt = prefixMatch && prefixMatch[1] === 'it'
+const t = (en: string, it: string) => (isIt ? it : en)
+
+const children = [
+  {
+    href: `${langPrefix}/services/consulting`,
+    title: t('Consulting', 'Consulenza'),
+    description: t(
+      'Hands-on help, from architecture to migration.',
+      "Supporto pratico, dall'architettura alla migrazione."
+    )
+  },
+  {
+    href: `${langPrefix}/services/training`,
+    title: t('Training', 'Formazione'),
+    description: t(
+      'Workshops for Django teams adopting Camomilla.',
+      'Workshop per team Django che adottano Camomilla.'
+    )
+  }
+]
+---
+
+<SiteLayout>
+  {
+    breadcrumbs.length > 1 && (
+      <nav class="breadcrumbs" aria-label="breadcrumb">
+        {breadcrumbs.map((crumb, i) => (
+          <span>
+            {i < breadcrumbs.length - 1 ? (
+              <a href={crumb.permalink}>{crumb.title}</a>
+            ) : (
+              <>{crumb.title}</>
+            )}
+          </span>
+        ))}
+      </nav>
+    )
+  }
+
+  <h1>{page?.title}</h1>
+  {page?.description && <p class="lead">{page.description}</p>}
+  {data.intro && <p>{data.intro}</p>}
+
+  <div class="grid grid-2">
+    {
+      children.map((child) => (
+        <a href={child.href} class="card" style="text-decoration:none;color:inherit;">
+          <h2 style="margin:0 0 .5rem;">{child.title}</h2>
+          <p style="margin:0;">{child.description}</p>
+        </a>
+      ))
+    }
+  </div>
+</SiteLayout>

--- a/packages/astro-camomilla-integration/package.json
+++ b/packages/astro-camomilla-integration/package.json
@@ -18,7 +18,9 @@
     "./layouts/MainLayout.astro": "./src/layouts/MainLayout.astro",
     "./components/ErrorRenderer.astro": "./src/components/ErrorRenderer.astro",
     "./components/CamomillaPicture.astro": "./src/components/CamomillaPicture.astro",
-    "./types/camomillaMedia": "./src/types/camomillaMedia.ts"
+    "./menus": "./src/menus.ts",
+    "./types/camomillaMedia": "./src/types/camomillaMedia.ts",
+    "./types/camomillaMenu": "./src/types/camomillaMenu.ts"
   },
   "scripts": {},
   "type": "module",

--- a/packages/astro-camomilla-integration/src/menus.ts
+++ b/packages/astro-camomilla-integration/src/menus.ts
@@ -1,0 +1,2 @@
+export { fetchMenu } from './utils/fetchMenu.ts'
+export type { CamomillaMenu, CamomillaMenuNode, CamomillaMenuLink } from './types/camomillaMenu.ts'

--- a/packages/astro-camomilla-integration/src/middleware/index.ts
+++ b/packages/astro-camomilla-integration/src/middleware/index.ts
@@ -17,9 +17,12 @@ async function middlewareCamomilla(context: APIContext, next: MiddlewareNext) {
   return next()
 }
 
+// User must run BEFORE page: the page middleware reads
+// ``context.locals.camomilla.user`` to decide whether to attempt the
+// authenticated preview flow for non-public pages.
 export const onRequest = sequence(
   middlewareCamomilla,
   middlewareCache,
-  middlewarePage,
-  middlewareUser
+  middlewareUser,
+  middlewarePage
 )

--- a/packages/astro-camomilla-integration/src/middleware/page.ts
+++ b/packages/astro-camomilla-integration/src/middleware/page.ts
@@ -1,11 +1,99 @@
 import type { MiddlewareHandler, APIContext, MiddlewareNext } from 'astro'
 import { extractForwardedHeaders } from '../utils/headers.ts'
-import type { CamomillaPage } from '../types/camomillaPage.ts'
+import {
+  isRedirectResponse,
+  type CamomillaRedirect,
+  type CamomillaRouterResponse
+} from '../types/camomillaPage.ts'
 import { getIntegrationOptions } from '../utils/getIntegrationOptions.ts'
+
+const STATIC_ASSET_PATH_RE =
+  /^\/(favicon\.ico|robots\.txt|manifest\.json|assets\/|.*\.(png|jpg|jpeg|gif|svg|webp|css|js|woff2?|ttf|otf|mp4|webm|txt|xml|json))$/
+
+/**
+ * Turn a camomilla ``{ redirect, status }`` router body into an absolute
+ * redirect Response. Shared by the public and preview paths — both routers
+ * can answer a permalink with a canonical redirect instead of a page.
+ */
+function toRedirect(context: APIContext, body: CamomillaRedirect): Response {
+  const baseUrl = context.url.href.replace(context.url.pathname, '')
+  return Response.redirect(`${baseUrl}${body.redirect}`, body.status)
+}
+
+/**
+ * Build the cookie + CSRF header pair used by the camomilla API for
+ * staff-authenticated requests. Returns ``null`` when either cookie is
+ * missing — the caller must treat that as "no preview attempt possible."
+ */
+async function buildAuthHeaders(
+  context: APIContext,
+  forwardedHeaders: string[]
+): Promise<Record<string, string> | null> {
+  const sessionCookie = await context.cookies.get('sessionid')
+  const csrfCookie = await context.cookies.get('csrftoken')
+  if (!sessionCookie || !csrfCookie) return null
+  return {
+    ...extractForwardedHeaders(context, forwardedHeaders),
+    Cookie: `sessionid=${sessionCookie.value}; csrftoken=${csrfCookie.value}`,
+    'X-CSRFToken': csrfCookie.value
+  }
+}
+
+/**
+ * Resolve a page by permalink via the authenticated preview router.
+ *
+ * Camomilla 6.4+ ships ``/api/camomilla/pages-router-preview/<permalink>``
+ * — same response shape as the public ``pages-router`` (``RouteSerializer``),
+ * but auth-required, bypasses the ``is_public`` gate, and overlays the
+ * active-language Draft with ``has_draft: true``. Returns the same shape
+ * for **public pages with a pending draft** too: the live row is the base
+ * and the draft fields are layered on top. This is the common preview
+ * case — editors checking what their pending edits will look like.
+ *
+ * Returns ``null`` when (a) the request lacks the session cookies needed
+ * to authenticate, or (b) the camomilla server denies the request
+ * (permission, missing permalink, …). Callers fall through to the public
+ * router in both cases.
+ */
+async function fetchPagePreview(
+  pathname: string,
+  context: APIContext
+): Promise<{ body: CamomillaRouterResponse; response: Response } | null> {
+  const { server, forwardedHeaders } = getIntegrationOptions()
+  const authHeaders = await buildAuthHeaders(context, forwardedHeaders)
+  if (!authHeaders) return null
+
+  const previewResp = await fetch(`${server}/api/camomilla/pages-router-preview${pathname}`, {
+    headers: authHeaders
+  })
+  if (!previewResp.ok) return null
+
+  const body = (await previewResp.json()) as CamomillaRouterResponse
+  return { body, response: previewResp }
+}
 
 /**
  * Middleware to handle page-related requests in the Camomilla integration.
  * It fetches the page data from the Camomilla server based on the request URL.
+ *
+ * Lifecycle (camomilla 6.4+):
+ *
+ * - Public requests hit ``pages-router``. The server gates on ``is_public``
+ *   after a lazy ``publish_if_due()`` attempt, so trashed / draft / scheduled
+ *   rows return 404. There is no client-side ``is_public`` check anymore.
+ *
+ * - Preview requests (``?preview=true``) attempt the authenticated preview
+ *   router **first** when the request carries valid session + CSRF cookies.
+ *   This handles every preview case uniformly:
+ *     · public page + pending draft → live shown with draft fields overlaid
+ *     · never-public page → bypass the is_public gate
+ *     · trashed / scheduled-first-publish → bypass the is_public gate
+ *   Going public-first would silently drop the overlay on already-live
+ *   pages, which is the most common preview case in practice.
+ *
+ *   Preview responses (and the public fallback for failed preview attempts)
+ *   are marked ``NEVER_CACHE`` so an editor's URL never poisons the shared
+ *   cache with a different user's view.
  */
 export const middlewarePage: MiddlewareHandler = async (
   context: APIContext,
@@ -13,47 +101,69 @@ export const middlewarePage: MiddlewareHandler = async (
 ) => {
   const { server, forwardedHeaders } = getIntegrationOptions()
   const serverUrl = server
-  if (
-    context.url.pathname.match(
-      /^\/(favicon\.ico|robots\.txt|manifest\.json|assets\/|.*\.(png|jpg|jpeg|gif|svg|webp|css|js|woff2?|ttf|otf|mp4|webm|txt|xml|json))$/
-    )
-  ) {
+
+  if (STATIC_ASSET_PATH_RE.test(context.url.pathname)) {
     return next()
   }
 
-  const resp = await fetch(`${serverUrl}/api/camomilla/pages-router${context.url.pathname}`, {
+  const previewRequested = context.url.searchParams?.get('preview') === 'true'
+
+  if (previewRequested) {
+    // Anything served on a ``?preview=true`` URL must not be cached: a
+    // subsequent visitor (different cookies, or none) hitting the same URL
+    // would otherwise receive this editor's view. Set the flag up-front so
+    // it applies whether the preview succeeds OR we fall through to public.
+    context.locals.camomilla.cache?.('NEVER_CACHE')
+
+    const preview = await fetchPagePreview(context.url.pathname, context)
+    if (preview) {
+      if (isRedirectResponse(preview.body)) return toRedirect(context, preview.body)
+      context.locals.camomilla.page = preview.body
+      context.locals.camomilla.page.is_preview = true
+      context.locals.camomilla.response = preview.response
+      context.locals.camomilla.template_file = preview.body.template_file
+      return next()
+    }
+    // Cookies absent, 403, or page truly missing — fall through to the
+    // public path so the caller still gets a sensible response (live page
+    // for already-public rows, 404 otherwise).
+  }
+
+  const publicResp = await fetch(`${serverUrl}/api/camomilla/pages-router${context.url.pathname}`, {
     headers: extractForwardedHeaders(context, forwardedHeaders)
   })
 
-  context.locals.camomilla.response = resp
-  if (resp.ok) {
-    const page = await resp.json()
-    context.locals.camomilla.page = page
-    if (page?.redirect && page.status == 301) {
-      const baseUrl = context.url.href.replace(context.url.pathname, '')
-      const redirectTo = `${baseUrl}${page.redirect}`
-      return Response.redirect(redirectTo, 301)
-    }
-    const preview = context.url.searchParams?.get('preview')
+  context.locals.camomilla.response = publicResp
 
-    if (page.is_public || preview === 'true') {
-      const { template_file } = page as CamomillaPage
-      context.locals.camomilla.template_file = template_file
-    } else {
-      context.locals.camomilla.response = new Response(page, {
+  if (publicResp.ok) {
+    const body = (await publicResp.json()) as CamomillaRouterResponse
+    if (isRedirectResponse(body)) return toRedirect(context, body)
+    // Back-compat with camomilla < 6.5.0: the old public router served
+    // non-public rows at 200 with ``is_public: false`` instead of 404ing
+    // them, so without this gate a draft would leak. No-op on 6.5.0+ (which
+    // 404s non-public rows server-side, so ``is_public`` is always true
+    // here). Skipped when previewing, matching the old behavior where
+    // ``?preview=true`` was allowed to see non-public pages.
+    if (!previewRequested && body.is_public === false) {
+      context.locals.camomilla.response = new Response('Not Public', {
         status: 404,
-        statusText: 'Not Public',
-        headers: resp.headers
+        statusText: 'Not Public'
       })
+      return next()
     }
-  } else {
-    const content = await resp.text()
-    context.locals.camomilla.error = { content }
-    try {
-      context.locals.camomilla.error.json = JSON.parse(content)
-    } catch (e) {
-      console.error(e)
-    }
+    context.locals.camomilla.page = body
+    context.locals.camomilla.template_file = body.template_file
+    return next()
   }
+
+  // Surface error body to the router so it can render a 404 / 5xx template.
+  const content = await publicResp.text()
+  context.locals.camomilla.error = { content }
+  try {
+    context.locals.camomilla.error.json = JSON.parse(content)
+  } catch (e) {
+    console.error(e)
+  }
+
   return next()
 }

--- a/packages/astro-camomilla-integration/src/types/camomillaMenu.ts
+++ b/packages/astro-camomilla-integration/src/types/camomillaMenu.ts
@@ -1,0 +1,35 @@
+/**
+ * Shape of a single navigable item inside a ``Menu``.
+ *
+ * Camomilla's ``MenuNodeLink`` distinguishes between relational links
+ * (``link_type: "RE"`` pointing at a ``UrlNode``) and static links
+ * (``link_type: "ST"`` with a hardcoded URL string). Either way, the
+ * serializer resolves a final ``url`` field so consumers don't have to
+ * branch on the type to render the anchor.
+ */
+export interface CamomillaMenuLink {
+  link_type: 'RE' | 'ST'
+  static?: string | null
+  url?: string | null
+  url_node?: {
+    id: number
+    permalink: string
+    related_name?: string
+  } | null
+  page?: { id: number; name: string; model: string } | null
+}
+
+export interface CamomillaMenuNode {
+  id?: string
+  title: string
+  link: CamomillaMenuLink
+  nodes: CamomillaMenuNode[]
+  meta?: Record<string, unknown>
+}
+
+export interface CamomillaMenu {
+  id: number
+  key: string
+  enabled: boolean
+  nodes: CamomillaMenuNode[]
+}

--- a/packages/astro-camomilla-integration/src/types/camomillaPage.ts
+++ b/packages/astro-camomilla-integration/src/types/camomillaPage.ts
@@ -1,7 +1,33 @@
+/**
+ * Page lifecycle label, derived server-side from ``published_at`` /
+ * ``deleted_at`` + the Draft table. Returned on every page-shaped response
+ * from ``/api/camomilla/pages-router`` and ``/api/camomilla/pages/<id>/``.
+ *
+ * - ``PUB`` published & publicly visible
+ * - ``DRF`` draft (never published in the active language)
+ * - ``PLA`` scheduled (legacy: ``published_at`` in the future)
+ * - ``TRS`` trashed (soft-deleted globally)
+ */
+export type CamomillaPageStatus = 'PUB' | 'DRF' | 'PLA' | 'TRS'
+
 export interface CamomillaPage {
   id: number
   is_public: boolean
-  status: number
+  status: CamomillaPageStatus
+  /**
+   * Present only on the authenticated preview response
+   * (``/api/camomilla/pages/<id>/preview/``). The public router omits these
+   * by design so it can't leak draft presence.
+   */
+  has_draft?: boolean
+  has_scheduled_draft?: boolean
+  /**
+   * Set by the integration (not the server) when this page was resolved
+   * through the authenticated preview router. Reliable "we're rendering a
+   * preview" signal — true for every previewed state, including a non-public
+   * page with no pending Draft (where ``has_draft`` is false).
+   */
+  is_preview?: boolean
   indexable: boolean
   alternates: Record<string, string | null>
   permalink: string
@@ -28,7 +54,13 @@ export interface CamomillaPage {
   template: string
   template_data: Record<string, unknown>
   ordering: number
-  publication_date: string | null
+  /**
+   * Timestamp at which the active language's content went / will go public.
+   * ``null`` means the language has never been published. Replaced the old
+   * ``publication_date`` field — the lifecycle column was removed in camomilla
+   * 6.4+ and ``published_at`` is now the single source of truth (per language).
+   */
+  published_at: string | null
   autopermalink: boolean
   og_image: string | null
   parent_page: string | null
@@ -37,5 +69,20 @@ export interface CamomillaPage {
     permalink: string
     related_name: string
   }
-  redirect: string | null
+}
+
+/**
+ * Body shape returned by ``pages-router`` when the requested permalink
+ * matches a ``UrlRedirect`` row. Disjoint from ``CamomillaPage`` — the
+ * router emits one or the other.
+ */
+export interface CamomillaRedirect {
+  redirect: string
+  status: number
+}
+
+export type CamomillaRouterResponse = CamomillaPage | CamomillaRedirect
+
+export function isRedirectResponse(value: CamomillaRouterResponse): value is CamomillaRedirect {
+  return typeof (value as CamomillaRedirect).redirect === 'string'
 }

--- a/packages/astro-camomilla-integration/src/utils/fetchMenu.ts
+++ b/packages/astro-camomilla-integration/src/utils/fetchMenu.ts
@@ -1,0 +1,76 @@
+import type { APIContext } from 'astro'
+import { extractForwardedHeaders } from './headers.ts'
+import { getIntegrationOptions } from './getIntegrationOptions.ts'
+import type { CamomillaMenu } from '../types/camomillaMenu.ts'
+
+/**
+ * Per-request memo: the same render often asks for the same menu more
+ * than once (e.g. header + footer + a sidebar). Keyed by the APIContext
+ * so it scopes to a single request and gets garbage-collected with it.
+ */
+const REQUEST_CACHE = new WeakMap<APIContext, Map<string, CamomillaMenu | null>>()
+
+async function buildAuthHeaders(
+  context: APIContext,
+  forwardedHeaders: string[]
+): Promise<Record<string, string>> {
+  const headers: Record<string, string> = extractForwardedHeaders(context, forwardedHeaders)
+  const sessionCookie = await context.cookies.get('sessionid')
+  const csrfCookie = await context.cookies.get('csrftoken')
+  if (sessionCookie && csrfCookie) {
+    headers.Cookie = `sessionid=${sessionCookie.value}; csrftoken=${csrfCookie.value}`
+    headers['X-CSRFToken'] = csrfCookie.value
+  }
+  return headers
+}
+
+/**
+ * Fetch a camomilla menu by its ``key`` (e.g. ``"main"``, ``"footer"``).
+ *
+ * Uses the visitor's session cookies if present, so logged-in staff see
+ * menus immediately. Camomilla's default ``MenuViewSet`` requires
+ * authentication; if you want anonymous visitors to see menus, expose
+ * the endpoint publicly server-side (override
+ * ``MenuViewSet.permission_classes`` in your project) — the
+ * ``fetchMenu`` helper itself doesn't care which auth strategy you pick,
+ * it just forwards whatever cookies the visitor brought.
+ *
+ * Active-language aware: detects the language prefix on the current URL
+ * (``/it/...``) and asks the API for that language so the menu's
+ * translatable ``nodes`` come back in the same locale the page is
+ * rendering in.
+ *
+ * Per-request memoized: calling ``fetchMenu("main", Astro)`` from both
+ * a header and a footer in the same render only round-trips to camomilla
+ * once.
+ *
+ * Returns ``null`` on any failure path (auth denied, missing key, network
+ * error). Callers should render gracefully — usually "no menu shown".
+ */
+export async function fetchMenu(key: string, context: APIContext): Promise<CamomillaMenu | null> {
+  let cache = REQUEST_CACHE.get(context)
+  if (!cache) {
+    cache = new Map()
+    REQUEST_CACHE.set(context, cache)
+  }
+  if (cache.has(key)) return cache.get(key) ?? null
+
+  const { server, forwardedHeaders } = getIntegrationOptions()
+  const headers = await buildAuthHeaders(context, forwardedHeaders)
+
+  const pathname = context.url.pathname
+  const prefixMatch = pathname.match(/^\/([a-z]{2})(\/|$)/)
+  const activeLang = prefixMatch ? prefixMatch[1] : null
+
+  const url = new URL(`${server}/api/camomilla/menus/${encodeURIComponent(key)}/`)
+  if (activeLang) url.searchParams.set('language', activeLang)
+
+  const resp = await fetch(url.toString(), { headers })
+  if (!resp.ok) {
+    cache.set(key, null)
+    return null
+  }
+  const menu = (await resp.json()) as CamomillaMenu
+  cache.set(key, menu)
+  return menu
+}

--- a/tests/integration/fetch-menu.test.ts
+++ b/tests/integration/fetch-menu.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+import createFetchMock from 'vitest-fetch-mock'
+import { createMockContext } from './helpers/libs.ts'
+
+vi.mock('../../packages/astro-camomilla-integration/src/utils/getIntegrationOptions', () => ({
+  getIntegrationOptions: vi.fn(() => ({
+    server: 'http://localhost:8000'
+  }))
+}))
+
+import { fetchMenu } from '../../packages/astro-camomilla-integration/src/utils/fetchMenu.ts'
+// Import via the public barrel too so the ``./menus`` export entry-point
+// is exercised by coverage and stays in lockstep with what consumers import.
+import * as menusBarrel from '../../packages/astro-camomilla-integration/src/menus.ts'
+
+const fetchMocker = createFetchMock(vi)
+fetchMocker.enableMocks()
+
+describe('fetchMenu', () => {
+  it('Public ``./menus`` barrel re-exports fetchMenu', () => {
+    expect(menusBarrel.fetchMenu).toBe(fetchMenu)
+  })
+
+  it('Returns null when no session cookies are present', async () => {
+    // The fetcher must not blindly hit the API when the visitor can't
+    // possibly be authenticated — the camomilla menu endpoint requires
+    // auth by default and we don't want anonymous 401s on every render.
+    const calls: string[] = []
+    fetchMocker.mockIf(/.*/, (req) => {
+      calls.push(req.url)
+      return { status: 401, body: 'unauth' }
+    })
+    const ctx = createMockContext(/* authenticated */ false)
+    const menu = await fetchMenu('main', ctx as any)
+    expect(menu).toBeNull()
+    // It's fine if the fetcher still attempts the request (the helper
+    // forwards-whatever-cookies and lets the server decide), but the
+    // result must always be null when the response isn't OK.
+    // We don't assert call count here — just behavior.
+  })
+
+  it('Returns the menu when the server responds 200', async () => {
+    fetchMocker.mockIf(/.*/, () => ({
+      status: 200,
+      body: JSON.stringify({
+        id: 1,
+        key: 'main',
+        enabled: true,
+        nodes: [{ title: 'About', link: { link_type: 'RE', url: '/about/' }, nodes: [] }]
+      })
+    }))
+    const ctx = createMockContext(true)
+    const menu = await fetchMenu('main', ctx as any)
+    expect(menu).not.toBeNull()
+    expect(menu?.key).toBe('main')
+    expect(menu?.nodes).toHaveLength(1)
+    expect(menu?.nodes[0].title).toBe('About')
+  })
+
+  it('Returns null when the server responds non-OK', async () => {
+    fetchMocker.mockIf(/.*/, () => ({ status: 403, body: 'forbidden' }))
+    const ctx = createMockContext(true)
+    const menu = await fetchMenu('main', ctx as any)
+    expect(menu).toBeNull()
+  })
+
+  it('Memoizes per APIContext: second call hits the cache', async () => {
+    let hits = 0
+    fetchMocker.mockIf(/.*/, () => {
+      hits += 1
+      return {
+        status: 200,
+        body: JSON.stringify({ id: 1, key: 'main', enabled: true, nodes: [] })
+      }
+    })
+    const ctx = createMockContext(true)
+    await fetchMenu('main', ctx as any)
+    await fetchMenu('main', ctx as any)
+    expect(hits).toBe(1)
+  })
+
+  it('Memoizes null results too: a failed first call short-circuits the second', async () => {
+    let hits = 0
+    fetchMocker.mockIf(/.*/, () => {
+      hits += 1
+      return { status: 403, body: 'forbidden' }
+    })
+    const ctx = createMockContext(true)
+    expect(await fetchMenu('main', ctx as any)).toBeNull()
+    expect(await fetchMenu('main', ctx as any)).toBeNull()
+    expect(hits).toBe(1)
+  })
+
+  it('Adds ?language=<code> when the request URL has a language prefix', async () => {
+    const seenUrls: string[] = []
+    fetchMocker.mockIf(/.*/, (req) => {
+      seenUrls.push(req.url)
+      return {
+        status: 200,
+        body: JSON.stringify({ id: 1, key: 'main', enabled: true, nodes: [] })
+      }
+    })
+    const ctx = createMockContext(true, 'http://localhost:8000/it/about', '/it/about')
+    await fetchMenu('main', ctx as any)
+    expect(seenUrls[0]).toContain('language=it')
+  })
+
+  it('Skips the language param on the default-locale (no prefix) URL', async () => {
+    const seenUrls: string[] = []
+    fetchMocker.mockIf(/.*/, (req) => {
+      seenUrls.push(req.url)
+      return {
+        status: 200,
+        body: JSON.stringify({ id: 1, key: 'main', enabled: true, nodes: [] })
+      }
+    })
+    const ctx = createMockContext(true, 'http://localhost:8000/about', '/about')
+    await fetchMenu('main', ctx as any)
+    expect(seenUrls[0]).not.toContain('language=')
+  })
+})

--- a/tests/integration/middleware-sequence.test.ts
+++ b/tests/integration/middleware-sequence.test.ts
@@ -57,7 +57,7 @@ describe('Middleware sequence', async () => {
         case req.url.endsWith('/api/camomilla/pages-router/'):
           return {
             status: 200,
-            body: JSON.stringify({ is_public: true })
+            body: JSON.stringify({ is_public: true, status: 'PUB' })
           }
         case req.url.endsWith('/api/camomilla/users/current/'):
           return {
@@ -110,13 +110,17 @@ describe('Middleware sequence', async () => {
     expect(headers['X-Forwarded-Host']).toBe('example.com')
     expect(headers['Referer']).toBe('http://example.com')
   })
-  it('Should handle draft pages', async () => {
+
+  // Camomilla 6.4+: the public ``pages-router`` 404s non-public pages
+  // (trashed / draft / scheduled-first-publish) server-side. The integration
+  // surfaces the failure response unchanged.
+  it('Should handle 404 from server for non-public pages', async () => {
     fetchMocker.mockIf(/^http?:\/\/localhost:8000.*$/, (req) => {
       switch (true) {
         case req.url.endsWith('/api/camomilla/pages-router/'):
           return {
-            status: 200,
-            body: JSON.stringify({ is_public: false })
+            status: 404,
+            body: 'Page is not public'
           }
         case req.url.endsWith('/api/camomilla/users/current/'):
           return {
@@ -134,31 +138,243 @@ describe('Middleware sequence', async () => {
       expect(ctxAuthenticated.locals.camomilla?.response?.status).toBe(404)
     else throw new Error('Response is not an instance of Response')
   })
-  it('Should handle preview draft pages', async () => {
+
+  // ``?preview=true`` without a valid session must NOT bypass the public
+  // gate — the lookup/preview call requires the cookies, and skipping it
+  // would leak draft state via an anonymous request.
+  it('Should not preview without session cookies even with ?preview=true', async () => {
     fetchMocker.mockIf(/^http?:\/\/localhost:8000.*$/, (req) => {
       switch (true) {
         case req.url.endsWith('/api/camomilla/pages-router/'):
+          return { status: 404, body: 'Page is not public' }
+        case req.url.endsWith('/api/camomilla/users/current/'):
+          return { status: 401, body: JSON.stringify({ user: null }) }
+      }
+    })
+
+    const ctxAnon = createMockContext(/* authenticated */ false)
+    ctxAnon.url.searchParams.set('preview', 'true')
+    const response = await onRequest(ctxAnon as any, async () => {
+      return new Response('Next middleware called')
+    })
+    if (response instanceof Response) expect(ctxAnon.locals.camomilla?.response?.status).toBe(404)
+    else throw new Error('Response is not an instance of Response')
+  })
+
+  // Public page + pending draft: ?preview=true must show the OVERLAID
+  // version, not the live one. This is the most common preview case —
+  // editors checking their pending edits to an already-live page. The
+  // middleware goes straight to ``pages-router-preview`` (no public fetch)
+  // so the overlay isn't silently dropped.
+  it('Should overlay draft on already-public pages when preview is requested', async () => {
+    let publicRouterHits = 0
+    fetchMocker.mockIf(/^http?:\/\/localhost:8000.*$/, (req) => {
+      switch (true) {
+        case req.url.includes('/api/camomilla/pages-router/about/'):
+          publicRouterHits += 1
           return {
             status: 200,
-            body: JSON.stringify({ is_public: false })
+            body: JSON.stringify({
+              id: 7,
+              is_public: true,
+              status: 'PUB',
+              template_file: 'default',
+              translations: { en: { title: 'live title' } }
+            })
           }
         case req.url.endsWith('/api/camomilla/users/current/'):
+          return { status: 200, body: JSON.stringify({ id: 1, is_staff: true }) }
+        case req.url.includes('/api/camomilla/pages-router-preview/about/'):
           return {
-            status: 401,
-            body: JSON.stringify({ user: {} })
+            status: 200,
+            body: JSON.stringify({
+              id: 7,
+              is_public: true,
+              status: 'PUB',
+              has_draft: true,
+              template_file: 'default',
+              translations: { en: { title: 'drafted title' } }
+            })
           }
       }
     })
 
-    const ctxAuthenticated = createMockContext(true)
-    ctxAuthenticated.url.searchParams.set('preview', 'true')
-    const response = await onRequest(ctxAuthenticated as any, async () => {
+    const ctxStaff = createMockContext(true, 'http://localhost:8000/about/', '/about/')
+    ctxStaff.url.searchParams.set('preview', 'true')
+    const response = await onRequest(ctxStaff as any, async () => {
+      return new Response('Next middleware called')
+    })
+    if (response instanceof Response) {
+      expect(ctxStaff.locals.camomilla?.response?.status).toBe(200)
+      const page = ctxStaff.locals.camomilla?.page as any
+      expect(page?.is_public).toBe(true)
+      expect(page?.has_draft).toBe(true)
+      // The drafted title wins over the live one.
+      expect(page?.translations?.en?.title).toBe('drafted title')
+      // Public router must NOT be hit when preview succeeds — single
+      // round-trip, no wasted call.
+      expect(publicRouterHits).toBe(0)
+    } else throw new Error('Response is not an instance of Response')
+  })
+
+  // Staff preview path for a non-public page: pages-router-preview returns
+  // the page bypassing the is_public gate. Public router never called.
+  it('Should handle preview for staff users via the preview router', async () => {
+    fetchMocker.mockIf(/^http?:\/\/localhost:8000.*$/, (req) => {
+      switch (true) {
+        case req.url.includes('/api/camomilla/pages-router/about/'):
+          return { status: 404, body: 'Page is not public' }
+        case req.url.endsWith('/api/camomilla/users/current/'):
+          return { status: 200, body: JSON.stringify({ id: 1, is_staff: true }) }
+        case req.url.includes('/api/camomilla/pages-router-preview/about/'):
+          return {
+            status: 200,
+            body: JSON.stringify({
+              id: 42,
+              is_public: false,
+              status: 'DRF',
+              has_draft: true,
+              template_file: 'default'
+            })
+          }
+      }
+    })
+
+    const ctxStaff = createMockContext(true, 'http://localhost:8000/about/', '/about/')
+    ctxStaff.url.searchParams.set('preview', 'true')
+    const response = await onRequest(ctxStaff as any, async () => {
+      return new Response('Next middleware called')
+    })
+    if (response instanceof Response) {
+      expect(ctxStaff.locals.camomilla?.response?.status).toBe(200)
+      expect((ctxStaff.locals.camomilla?.page as any)?.has_draft).toBe(true)
+      // The integration flags every previewed render so consumers (e.g. a
+      // preview banner) can key off it even when no draft overlay applies.
+      expect((ctxStaff.locals.camomilla?.page as any)?.is_preview).toBe(true)
+      expect((ctxStaff.locals.camomilla as any)?.template_file).toBe('default')
+    } else throw new Error('Response is not an instance of Response')
+  })
+
+  // The preview router can answer a non-canonical permalink with a
+  // ``{ redirect, status }`` body just like the public one. The preview
+  // path must honor it — not treat it as a page (undefined template_file).
+  it('Should honor a canonical redirect from the preview router', async () => {
+    fetchMocker.mockIf(/^http?:\/\/localhost:8000.*$/, (req) => {
+      switch (true) {
+        case req.url.endsWith('/api/camomilla/users/current/'):
+          return { status: 200, body: JSON.stringify({ id: 1, is_staff: true }) }
+        case req.url.includes('/api/camomilla/pages-router-preview/old-about/'):
+          return {
+            status: 200,
+            body: JSON.stringify({ redirect: '/about/', status: 301 })
+          }
+      }
+    })
+
+    const ctxStaff = createMockContext(true, 'http://localhost:8000/old-about/', '/old-about/')
+    ctxStaff.url.searchParams.set('preview', 'true')
+    const response = await onRequest(ctxStaff as any, async () => {
+      return new Response('Next middleware called')
+    })
+    if (response instanceof Response) {
+      expect(response.status).toBe(301)
+      expect(response.headers.get('location')).toContain('/about/')
+    } else throw new Error('Response is not an instance of Response')
+  })
+
+  // ``buildAuthHeaders`` returns ``null`` if either cookie is missing. The
+  // sessionid-only case is the typical "logged out partway" state — we
+  // must not attempt the preview, just like the cookie-less request.
+  it('Should not attempt preview when only one auth cookie is present', async () => {
+    fetchMocker.mockIf(/^http?:\/\/localhost:8000.*$/, () => {
+      return { status: 404, body: 'Page is not public' }
+    })
+
+    const ctx = createMockContext(false)
+    // Only sessionid, no csrftoken
+    ctx.cookies.set('sessionid', 'mock-session-id')
+    ctx.url.searchParams.set('preview', 'true')
+    const response = await onRequest(ctx as any, async () => {
+      return new Response('Next middleware called')
+    })
+    if (response instanceof Response) expect(ctx.locals.camomilla?.response?.status).toBe(404)
+    else throw new Error('Response is not an instance of Response')
+  })
+
+  // If the preview router denies access (e.g. user has cookies but isn't
+  // actually staff, so 403), fall back to the public 404.
+  it('Should fall back to 404 when the preview router denies access', async () => {
+    fetchMocker.mockIf(/^http?:\/\/localhost:8000.*$/, (req) => {
+      switch (true) {
+        case req.url.endsWith('/api/camomilla/pages-router/'):
+          return { status: 404, body: 'Page is not public' }
+        case req.url.endsWith('/api/camomilla/users/current/'):
+          return { status: 200, body: JSON.stringify({ id: 1, is_staff: false }) }
+        case req.url.includes('/api/camomilla/pages-router-preview/'):
+          return { status: 403, body: 'Forbidden' }
+      }
+    })
+
+    const ctxStaffless = createMockContext(true)
+    ctxStaffless.url.searchParams.set('preview', 'true')
+    const response = await onRequest(ctxStaffless as any, async () => {
       return new Response('Next middleware called')
     })
     if (response instanceof Response)
-      expect(ctxAuthenticated.locals.camomilla?.response?.status).toBe(200)
+      expect(ctxStaffless.locals.camomilla?.response?.status).toBe(404)
     else throw new Error('Response is not an instance of Response')
   })
+
+  // Back-compat with camomilla < 6.5.0: the old public router served
+  // non-public rows at 200 with ``is_public: false`` instead of 404ing.
+  // The integration must still gate them so drafts don't leak on old servers.
+  it('Should 404 a non-public 200 response (old camomilla back-compat)', async () => {
+    fetchMocker.mockIf(/^http?:\/\/localhost:8000.*$/, (req) => {
+      switch (true) {
+        case req.url.endsWith('/api/camomilla/pages-router/'):
+          return { status: 200, body: JSON.stringify({ is_public: false, status: 0 }) }
+        case req.url.endsWith('/api/camomilla/users/current/'):
+          return { status: 401, body: JSON.stringify({ user: null }) }
+      }
+    })
+
+    const ctx = createMockContext(false)
+    const response = await onRequest(ctx as any, async () => {
+      return new Response('Next middleware called')
+    })
+    if (response instanceof Response) expect(ctx.locals.camomilla?.response?.status).toBe(404)
+    else throw new Error('Response is not an instance of Response')
+  })
+
+  // …but the back-compat gate must NOT fire on ?preview=true, so previewing
+  // a draft still works on old camomilla (where the preview router 404s and
+  // we fall through to the public 200 draft).
+  it('Should render a non-public preview on old camomilla (gate bypassed)', async () => {
+    fetchMocker.mockIf(/^http?:\/\/localhost:8000.*$/, (req) => {
+      switch (true) {
+        case req.url.includes('/api/camomilla/pages-router-preview/'):
+          return { status: 404, body: 'Not Found' }
+        case req.url.endsWith('/api/camomilla/pages-router/'):
+          return {
+            status: 200,
+            body: JSON.stringify({ is_public: false, status: 0, template_file: 'default' })
+          }
+        case req.url.endsWith('/api/camomilla/users/current/'):
+          return { status: 200, body: JSON.stringify({ id: 1, is_staff: true }) }
+      }
+    })
+
+    const ctxStaff = createMockContext(true)
+    ctxStaff.url.searchParams.set('preview', 'true')
+    const response = await onRequest(ctxStaff as any, async () => {
+      return new Response('Next middleware called')
+    })
+    if (response instanceof Response) {
+      expect(ctxStaff.locals.camomilla?.response?.status).toBe(200)
+      expect((ctxStaff.locals.camomilla as any)?.template_file).toBe('default')
+    } else throw new Error('Response is not an instance of Response')
+  })
+
   it('Should handle error responses 500', async () => {
     fetchMocker.mockIf(/^http?:\/\/localhost:8000.*$/, (req) => {
       switch (true) {


### PR DESCRIPTION
## Summary

Adapts the integration to **camomilla 6.5**'s new page lifecycle and adds menu support.

- **Server-side visibility** — the public `pages-router` now gates on `is_public` itself (404s trashed/draft/scheduled rows), so the client-side check is removed.
- **Authenticated preview** — `?preview=true` hits `pages-router-preview` first (draft overlay + `is_public` bypass), marked `NEVER_CACHE`, falling through to the public router when cookies are absent / 403 / 404.
- **Menus** — new `fetchMenu` helper (per-request memoized, language-prefix aware, cookie-forwarding) exposed via `./menus`.
- **Demo site** — example header/footer/menu/lang-switch/preview-banner + site templates mirroring camomilla's `seed_demo`.

## Commits

| Scope | Change |
|-------|--------|
| `feat(middleware)` | Page lifecycle + preview router; `status`/`published_at`/`has_draft`/`is_preview` types; middleware order (`user` before `page`) |
| `feat(menus)` | `fetchMenu` helper + menu types, `./menus` export |
| `chore(example)` | Demo site (layout, header, footer, menus, preview banner, templates, styles) |
| `docs` | Rewrite the Draft Pages / preview section of the README |

## Compatibility

Targets **camomilla ≥ 6.5.0** (the lifecycle API — preview router, timestamp-derived `status`, `has_draft` — is new in 6.5.0).

Against older camomilla it degrades safely rather than crashing:
- A back-compat guard re-404s any `is_public: false` page served at 200, so **drafts don't leak** (no-op on 6.5.0+).
- `?preview=true` falls through to the public router and renders without an overlay. ⚠️ On old camomilla this preview view is **unauthenticated** (the auth-enforcing preview endpoint doesn't exist there) — same as the previous integration behavior, but worth noting for public-facing old-camomilla sites.

## Testing

`pnpm test:integration` → **57 passing** (added coverage for preview overlay, preview redirects, the auth-cookie gating, and the old-camomilla back-compat guard). Lint clean.